### PR TITLE
Fix package

### DIFF
--- a/thesaurus.el
+++ b/thesaurus.el
@@ -1,4 +1,4 @@
-;;; thesaurus.el ---  Query thesaurus.com for synonyms of a given word
+;;; thesaurus.el ---  Query thesaurus.com for synonyms of a given word -*- lexical-binding: t; -*-
 
 ;;; Copyright (C) 2022 by Anselm Coogan
 ;;; URL: https://github.com/AnselmC/thesaurus
@@ -23,8 +23,6 @@
 ;;; Uses the Elisp request library (https://github.com/tkf/emacs-request) and the thesaurus.com API to fetch synonyms
 
 ;;; Code:
-
-;; -*- lexical-binding: t; -*-
 
 (require 'cl-lib)
 (require 'request)
@@ -69,7 +67,7 @@
          (word (buffer-substring-no-properties (car bounds) (cdr bounds)))
          (replace-text (completing-read
                         (format "Select synonym for %S: " word)
-                        (append (ask-thesaurus-for-synonyms word) '()))))
+                        (append (thesaurus-ask-thesaurus-for-synonyms word) '()))))
     (when bounds
       (delete-region (car bounds) (cdr bounds))
       (insert replace-text))))


### PR DESCRIPTION
- Move lexical-binding setting. Because it should be at first line
- Correct function name

If lexical-binding is enabled, then major-mode in mode-line is as below(`Elisp/l` , `l` stands for lexical) when you open this file

![image](https://user-images.githubusercontent.com/554281/164700609-0b0fad52-da66-44e7-b67a-5141e487c2e1.png)

While lexical-binding is disabled then it is as below(`Elisp/d`, `d` stands for dynamic)

![image](https://user-images.githubusercontent.com/554281/164700552-8a25e484-4e23-4c22-8810-637af4ec6c23.png)




